### PR TITLE
Add registration link for shiny workshop

### DIFF
--- a/tutorial_AM1.html
+++ b/tutorial_AM1.html
@@ -67,7 +67,13 @@
 <br>
 <strong> Background </strong>
 <br>
-This tutorial is suitable for R users needing to share data and results in interactive web applications. There is no need for prior experience in website development or shiny to get the most out of this tutorial. This tutorial is packed with content, and so familiarity with writing R code is essential. Some familiarity with tidyverse packages including dplyr and ggplot2 would also be beneficial to fully understand the demonstrated apps. If you are unfamiliar with writing R code or using the tidyverse, consider working through the learnr materials here: <a href="http://learnr.numbat.space/">https://learnr.numbat.space/</a></p>.
+<p>This tutorial is suitable for R users needing to share data and results in interactive web applications. There is no need for prior experience in website development or shiny to get the most out of this tutorial. This tutorial is packed with content, and so familiarity with writing R code is essential. Some familiarity with tidyverse packages including dplyr and ggplot2 would also be beneficial to fully understand the demonstrated apps. If you are unfamiliar with writing R code or using the tidyverse, consider working through the learnr materials here: <a href="http://learnr.numbat.space/">https://learnr.numbat.space/</a></p>.
+
+
+<br>
+<strong> Register </strong>
+<br>
+<p>Register for this tutorial at <a href="https://events.humanitix.com/wombat-2024-day-1">https://events.humanitix.com/wombat-2024-day-1</a>.</p>
 <br>
 <br>
 


### PR DESCRIPTION
Should help registration flow, as participants can read about the workshop and immediately click through to registration.